### PR TITLE
Handle chat time in feed

### DIFF
--- a/Readme.MD
+++ b/Readme.MD
@@ -11,6 +11,7 @@ A Chrome Extension to track time spent on:
 
 - Tracks time only on the **active tab**
 - Categorizes activity based on page URL
+- Detects chat windows in the feed to record messaging time
 - Displays a summary in the popup
 - Allows reset of all data
 
@@ -38,7 +39,7 @@ Edit
 
 ## How it Works
 
-- `content.js` runs on each page and determines the activity category.
+- `content.js` runs on each page and determines the activity category, including detecting chat windows within the feed.
 - `background.js` stores the activity time per category.
 - `popup.html` shows the tracked time and allows resetting.
 

--- a/content.js
+++ b/content.js
@@ -20,9 +20,32 @@ function determineCategory(url, customKeywords) {
   return null;
 }
 
+function isMessagingElement(element) {
+  let el = element;
+  while (el && el !== document.body) {
+    const id = el.id ? el.id.toLowerCase() : '';
+    const cls = el.className ? el.className.toLowerCase() : '';
+    if (/chat|msg|messag/.test(id) || /chat|msg|messag/.test(cls)) {
+      return true;
+    }
+    el = el.parentElement;
+  }
+  return false;
+}
+
+function setCategory(newCategory) {
+  if (currentCategory !== newCategory) {
+    trackActivity();
+    currentCategory = newCategory;
+  }
+}
+
 function updateCategory() {
   chrome.storage.sync.get('customKeywords', (data) => {
-    currentCategory = determineCategory(window.location.href, data.customKeywords);
+    const determined = determineCategory(window.location.href, data.customKeywords);
+    if (determined) {
+      setCategory(determined);
+    }
   });
 }
 
@@ -45,6 +68,14 @@ window.addEventListener('focus', () => {
 
 window.addEventListener('blur', () => {
   trackActivity();
+});
+
+document.addEventListener('focusin', (e) => {
+  if (isMessagingElement(e.target)) {
+    setCategory('chatting');
+  } else if (currentCategory === 'chatting') {
+    updateCategory();
+  }
 });
 
 updateCategory();


### PR DESCRIPTION
## Summary
- classify time spent in chat windows in feed pages as messaging time
- log time whenever the active category changes
- update docs with new behaviour

## Testing
- `node -c content.js`
- `node -c background.js`
- `node -c popup.js`
- `node -c options.js`


------
https://chatgpt.com/codex/tasks/task_e_687b163da0f88324b7e6b3d55c2e9ffc