### PR TITLE
Add statistics page with summaries

### DIFF
--- a/Readme.MD
+++ b/Readme.MD
@@ -17,6 +17,7 @@ A Chrome Extension to track time spent on:
 - Allows reset of all data
 - Custom categories and idle/notification thresholds
 - Optional desktop reminders with a Pomodoro timer
+- Statistics page with daily, weekly and monthly summaries
 
 ## Installation
 
@@ -34,6 +35,8 @@ chrome-time-tracker/
 ├── popup.html
 ├── popup.js
 ├── styles.css
+├── visualization.html
+├── visualization.js
 └── README.md
 
 markdown
@@ -44,7 +47,7 @@ Edit
 
 - `content.js` runs on each page and determines the activity category, including detecting chat windows within the feed.
 - `background.js` stores the activity time per category.
-- `popup.html` shows the tracked time and allows resetting.
+- `popup.html` shows the tracked time and allows resetting. You can open `visualization.html` from the popup to view daily, weekly and monthly summaries.
 
 ## Permissions
 

--- a/background.js
+++ b/background.js
@@ -38,11 +38,16 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (request.type === 'logActivity') {
     const { category, timeSpent } = request.payload;
 
-    chrome.storage.local.get(['activityLog'], result => {
+    chrome.storage.local.get(['activityLog', 'activityHistory'], result => {
       const log = result.activityLog || {};
+      const history = result.activityHistory || {};
       log[category] = (log[category] || 0) + timeSpent;
 
-      chrome.storage.local.set({ activityLog: log }, () => {
+      const today = new Date().toISOString().slice(0, 10);
+      history[today] = history[today] || {};
+      history[today][category] = (history[today][category] || 0) + timeSpent;
+
+      chrome.storage.local.set({ activityLog: log, activityHistory: history }, () => {
         checkThreshold(category, log[category]);
       });
     });

--- a/popup.html
+++ b/popup.html
@@ -12,7 +12,13 @@
     <ul id="logList"></ul>
     <button id="resetBtn">Reset</button>
     <button id="pomodoroBtn">Start Pomodoro</button>
+    <button id="statsBtn">View Stats</button>
   </div>
   <script src="popup.js"></script>
+  <script>
+    document.getElementById('statsBtn').addEventListener('click', () => {
+      chrome.tabs.create({ url: 'visualization.html' });
+    });
+  </script>
 </body>
 </html>

--- a/visualization.html
+++ b/visualization.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Time Tracker Stats</title>
+  <link rel="stylesheet" href="styles.css" />
+  <style>
+    .chart-bar { background-color: var(--accent-color); height: 20px; margin: 2px 0; }
+    .summary { margin-bottom: 20px; }
+    .summary h3 { margin: 0 0 4px 0; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h2>Statistics</h2>
+    <div id="daily" class="summary"></div>
+    <div id="weekly" class="summary"></div>
+    <div id="monthly" class="summary"></div>
+  </div>
+  <script src="visualization.js"></script>
+</body>
+</html>

--- a/visualization.js
+++ b/visualization.js
@@ -1,0 +1,49 @@
+function formatTime(seconds) {
+  const hrs = Math.floor(seconds / 3600);
+  const mins = Math.floor((seconds % 3600) / 60);
+  const parts = [];
+  if (hrs) parts.push(`${hrs}h`);
+  if (mins || !hrs) parts.push(`${mins}m`);
+  return parts.join(' ');
+}
+
+function summarize(history, days) {
+  const sum = {};
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - days + 1);
+  for (const [date, cats] of Object.entries(history)) {
+    const d = new Date(date);
+    if (d < cutoff) continue;
+    for (const [cat, val] of Object.entries(cats)) {
+      sum[cat] = (sum[cat] || 0) + val;
+    }
+  }
+  return sum;
+}
+
+function renderSection(el, title, summary, days) {
+  el.innerHTML = `<h3>${title}</h3>`;
+  let total = 0;
+  for (const val of Object.values(summary)) total += val;
+  const avg = total / days;
+  const ul = document.createElement('ul');
+  for (const [cat, val] of Object.entries(summary)) {
+    const li = document.createElement('li');
+    li.textContent = `${cat.replace('_',' ')}: ${formatTime(val)}`;
+    ul.appendChild(li);
+  }
+  const avgEl = document.createElement('div');
+  avgEl.textContent = `Average per day: ${formatTime(Math.round(avg))}`;
+  el.appendChild(ul);
+  el.appendChild(avgEl);
+}
+
+chrome.storage.local.get('activityHistory', ({ activityHistory }) => {
+  const history = activityHistory || {};
+  const daily = summarize(history, 1);
+  const weekly = summarize(history, 7);
+  const monthly = summarize(history, 30);
+  renderSection(document.getElementById('daily'), 'Today', daily, 1);
+  renderSection(document.getElementById('weekly'), 'Last 7 Days', weekly, 7);
+  renderSection(document.getElementById('monthly'), 'Last 30 Days', monthly, 30);
+});


### PR DESCRIPTION
## Summary
- store daily activity history in background script
- add visualization page with daily/weekly/monthly summaries
- link stats page from popup
- document new feature in README

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_687b1d072a788324901ca6268607138a