### PR TITLE
Restrict tracker to LinkedIn active tab

### DIFF
--- a/Readme.MD
+++ b/Readme.MD
@@ -10,7 +10,7 @@ A Chrome Extension to track time spent on:
 ## Features
 
 - Tracks time only on the **active tab**
-- Works exclusively on [LinkedIn](https://www.linkedin.com)
+- Works exclusively on [LinkedIn](https://www.linkedin.com) (only `www.linkedin.com` pages)
 - Categorizes activity based on page URL
 - Detects chat windows in the feed to record messaging time
 - Logs browsing time in real time while a tab is focused

--- a/content.js
+++ b/content.js
@@ -4,7 +4,8 @@ let currentCategory = null;
 let intervalId = null;
 let idleThreshold = 60;
 let isIdle = false;
-const isLinkedIn = window.location.href.startsWith('https://www.linkedin.com');
+// Only enable the tracker on the main LinkedIn site
+const isLinkedIn = window.location.hostname === 'www.linkedin.com';
 
 function formatOverlayTime(seconds) {
   const m = Math.floor(seconds / 60);
@@ -79,7 +80,7 @@ function trackActivity() {
 function startInterval() {
   if (!intervalId) {
     intervalId = setInterval(() => {
-      if (document.hasFocus()) {
+      if (document.visibilityState === 'visible' && document.hasFocus()) {
         trackActivity();
       }
     }, 5000);
@@ -157,7 +158,7 @@ document.head.appendChild(style);
 
 let overlaySeconds = 0;
 setInterval(() => {
-  if (document.hasFocus() && !isIdle && currentCategory) {
+  if (document.visibilityState === 'visible' && document.hasFocus() && !isIdle && currentCategory) {
     overlaySeconds++;
     overlay.textContent = `${currentCategory.replace('_',' ')}: ${formatOverlayTime(overlaySeconds)}`;
     overlay.style.display = 'block';

--- a/manifest.json
+++ b/manifest.json
@@ -10,6 +10,9 @@
     "scripting",
     "notifications"
   ],
+  "host_permissions": [
+    "https://www.linkedin.com/*"
+  ],
   "options_page": "options.html",
   "background": {
     "service_worker": "background.js"


### PR DESCRIPTION
## Summary
- limit content script execution strictly to `www.linkedin.com`
- add host permissions to manifest
- show tracker only when the tab is visible
- document new behaviour in README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687c157be57c83249981522114cebdb9