### PR TITLE
Fix overlay timer reset logic and add customization options

### DIFF
--- a/Readme.MD
+++ b/Readme.MD
@@ -17,6 +17,7 @@ A Chrome Extension to track time spent on:
 - Dynamic popup updates with an animated chart
 - Allows reset of all data
 - Custom categories and idle/notification thresholds
+- Movable on-page timer with optional delay and ability to disable
 - Statistics page with daily, weekly and monthly summaries
 - Refreshed modern interface
 - Gamification points and badges for productive time
@@ -40,10 +41,6 @@ chrome-time-tracker/
 ├── visualization.html
 ├── visualization.js
 └── README.md
-
-markdown
-Copy
-Edit
 
 ## How it Works
 

--- a/options.html
+++ b/options.html
@@ -46,6 +46,11 @@
     <label for="idleThreshold">Idle threshold (seconds):</label>
     <input type="number" id="idleThreshold" min="10" value="60" />
 
+    <label for="overlayDelay">Delay before timer shows (seconds):</label>
+    <input type="number" id="overlayDelay" min="0" value="0" />
+
+    <label><input type="checkbox" id="overlayEnabled" checked /> Enable on-page timer</label>
+
     <label for="categoryThresholds">Notification thresholds per category (JSON in seconds):</label>
     <textarea id="categoryThresholds" name="categoryThresholds">{}</textarea>
 

--- a/options.js
+++ b/options.js
@@ -5,6 +5,8 @@ document.getElementById('keywordForm').addEventListener('submit', function(e) {
   e.preventDefault();
   const keywords = document.getElementById('keywords').value;
   const idle = parseInt(document.getElementById('idleThreshold').value, 10) || 60;
+  const overlayDelay = parseInt(document.getElementById('overlayDelay').value, 10) || 0;
+  const overlayEnabled = document.getElementById('overlayEnabled').checked;
   const categoryThresh = document.getElementById('categoryThresholds').value;
   try {
     const parsedKeywords = JSON.parse(keywords);
@@ -12,7 +14,9 @@ document.getElementById('keywordForm').addEventListener('submit', function(e) {
     storage.set({
       customKeywords: parsedKeywords,
       idleThreshold: idle,
-      categoryThresholds: parsedThresh
+      categoryThresholds: parsedThresh,
+      overlayDelay,
+      overlayEnabled
     }, () => {
       alert('Options saved!');
     });
@@ -21,7 +25,7 @@ document.getElementById('keywordForm').addEventListener('submit', function(e) {
   }
 });
 
-storage.get(['customKeywords','idleThreshold','categoryThresholds'], (data) => {
+storage.get(['customKeywords','idleThreshold','categoryThresholds','overlayDelay','overlayEnabled'], (data) => {
   if (data.customKeywords) {
     document.getElementById('keywords').value = JSON.stringify(data.customKeywords, null, 2);
   }
@@ -30,5 +34,11 @@ storage.get(['customKeywords','idleThreshold','categoryThresholds'], (data) => {
   }
   if (data.categoryThresholds) {
     document.getElementById('categoryThresholds').value = JSON.stringify(data.categoryThresholds, null, 2);
+  }
+  if (typeof data.overlayDelay === 'number') {
+    document.getElementById('overlayDelay').value = data.overlayDelay;
+  }
+  if (typeof data.overlayEnabled === 'boolean') {
+    document.getElementById('overlayEnabled').checked = data.overlayEnabled;
   }
 });


### PR DESCRIPTION
## Summary
- preserve bottom-right timer when switching focus
- reset timer when switching categories
- allow delaying or disabling the on-page timer
- allow dragging the on-page timer
- document the new features in README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_687c33eef1b08324978458af47f4494b