### PR TITLE
Fix overlay timer reset and set default delay

### DIFF
--- a/content.js
+++ b/content.js
@@ -4,8 +4,10 @@ let currentCategory = null;
 let intervalId = null;
 let idleThreshold = 60;
 let isIdle = false;
-let overlayDelay = 0;
+let overlayDelay = 60;
 let overlayEnabled = true;
+let overlay;
+let overlaySeconds = 0;
 // Only enable the tracker on the main LinkedIn site
 const isLinkedIn = window.location.hostname === 'www.linkedin.com';
 let lastUrl = window.location.href;
@@ -59,6 +61,9 @@ function setCategory(newCategory) {
     trackActivity();
     currentCategory = newCategory;
     overlaySeconds = 0;
+    if (overlay) {
+      overlay.style.display = 'none';
+    }
   }
 }
 
@@ -161,8 +166,8 @@ if (isLinkedIn) {
   updateCategory();
   startInterval();
 
-  const overlay = document.createElement('div');
-overlay.id = 'timeTrackerOverlay';
+  overlay = document.createElement('div');
+  overlay.id = 'timeTrackerOverlay';
 overlay.style.position = 'fixed';
 overlay.style.bottom = '10px';
 overlay.style.right = '10px';
@@ -175,13 +180,13 @@ overlay.style.zIndex = '9999';
 overlay.style.pointerEvents = 'auto';
 overlay.style.display = 'none';
 overlay.style.animation = 'cttPulse 1s infinite';
-document.body.appendChild(overlay);
+  document.body.appendChild(overlay);
 
-const style = document.createElement('style');
-style.textContent = `@keyframes cttPulse {0%{opacity:.6;}50%{opacity:1;}100%{opacity:.6;}}`;
-document.head.appendChild(style);
+  const style = document.createElement('style');
+  style.textContent = `@keyframes cttPulse {0%{opacity:.6;}50%{opacity:1;}100%{opacity:.6;}}`;
+  document.head.appendChild(style);
 
-let overlaySeconds = 0;
+  overlaySeconds = 0;
 let dragging = false;
 let dragOffsetX = 0;
 let dragOffsetY = 0;

--- a/options.html
+++ b/options.html
@@ -62,7 +62,7 @@
     <input type="number" id="idleThreshold" min="10" value="60" />
 
     <label for="overlayDelay">Delay before timer shows (seconds):</label>
-    <input type="number" id="overlayDelay" min="0" value="0" />
+    <input type="number" id="overlayDelay" min="0" value="60" />
 
     <label><input type="checkbox" id="overlayEnabled" checked /> Enable on-page timer</label>
 

--- a/options.js
+++ b/options.js
@@ -5,7 +5,7 @@ document.getElementById('keywordForm').addEventListener('submit', function(e) {
   e.preventDefault();
   const keywords = document.getElementById('keywords').value;
   const idle = parseInt(document.getElementById('idleThreshold').value, 10) || 60;
-  const overlayDelay = parseInt(document.getElementById('overlayDelay').value, 10) || 0;
+  const overlayDelay = parseInt(document.getElementById('overlayDelay').value, 10) || 60;
   const overlayEnabled = document.getElementById('overlayEnabled').checked;
   const categoryThresh = document.getElementById('categoryThresholds').value;
   try {
@@ -37,6 +37,8 @@ storage.get(['customKeywords','idleThreshold','categoryThresholds','overlayDelay
   }
   if (typeof data.overlayDelay === 'number') {
     document.getElementById('overlayDelay').value = data.overlayDelay;
+  } else {
+    document.getElementById('overlayDelay').value = 60;
   }
   if (typeof data.overlayEnabled === 'boolean') {
     document.getElementById('overlayEnabled').checked = data.overlayEnabled;


### PR DESCRIPTION
## Summary
- start overlay after 60s by default
- hide overlay and reset timer when category changes

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687f31d4dce88324ab9aa58b83195e20